### PR TITLE
Fix serialization of datetime, date, time, and timedelta task arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Fixed a bug where the supervisor wouldn't respond to SIGINT while booting if
   Django was waiting on the database connection pool (#16).
+- Fixed serialization of `datetime`, `date`, `time`, and `timedelta` objects
+  passed as task arguments (#30).
 
 ## v0.1.4 - 2026-02-06
 

--- a/steady_queue/arguments.py
+++ b/steady_queue/arguments.py
@@ -1,3 +1,4 @@
+from datetime import date, datetime, time, timedelta
 from typing import Any
 
 from django.db import models
@@ -14,6 +15,10 @@ class SerializationError(ValueError):
 class Arguments:
     HASH_KEY = "__sq_hash__"
     MODEL_KEY = "__sq_model__"
+    DATETIME_KEY = "__sq_datetime__"
+    DATE_KEY = "__sq_date__"
+    TIME_KEY = "__sq_time__"
+    TIMEDELTA_KEY = "__sq_timedelta__"
 
     @classmethod
     def serialize_args_and_kwargs(cls, args, kwargs) -> dict[str, Any]:
@@ -53,6 +58,14 @@ class Arguments:
                     for key, value in argument.items()
                 }
             }
+        elif isinstance(argument, datetime):
+            return {cls.DATETIME_KEY: argument.isoformat()}
+        elif isinstance(argument, date):
+            return {cls.DATE_KEY: argument.isoformat()}
+        elif isinstance(argument, time):
+            return {cls.TIME_KEY: argument.isoformat()}
+        elif isinstance(argument, timedelta):
+            return {cls.TIMEDELTA_KEY: argument.total_seconds()}
         elif isinstance(argument, models.Model):
             return {
                 cls.MODEL_KEY: {
@@ -76,6 +89,14 @@ class Arguments:
                     key: cls.deserialize_argument(value)
                     for key, value in argument[cls.HASH_KEY].items()
                 }
+            elif cls.DATETIME_KEY in argument:
+                return datetime.fromisoformat(argument[cls.DATETIME_KEY])
+            elif cls.DATE_KEY in argument:
+                return date.fromisoformat(argument[cls.DATE_KEY])
+            elif cls.TIME_KEY in argument:
+                return time.fromisoformat(argument[cls.TIME_KEY])
+            elif cls.TIMEDELTA_KEY in argument:
+                return timedelta(seconds=argument[cls.TIMEDELTA_KEY])
             elif cls.MODEL_KEY in argument:
                 return cls._deserialize_model(argument[cls.MODEL_KEY])
 

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,4 +1,7 @@
+from datetime import date, datetime, time, timedelta, timezone
+
 from django.test import SimpleTestCase, TestCase
+from django.utils import timezone as dj_tz
 
 from steady_queue.arguments import Arguments
 from tests.dummy.models import Dummy
@@ -28,6 +31,70 @@ class TestArguments(SimpleTestCase):
             self.assertEqual(
                 [subject], Arguments.deserialize(Arguments.serialize([subject]))
             )
+
+    def test_datetime_serialization(self):
+        subjects = [
+            datetime(2026, 2, 12, 11, 21, 9, 976000),
+            date(2026, 2, 12),
+            time(11, 21, 9, 976000),
+        ]
+        for subject in subjects:
+            self.assertEqual(
+                [subject], Arguments.deserialize(Arguments.serialize([subject]))
+            )
+
+    def test_datetime_as_kwarg(self):
+        args = (1,)
+        kwargs = {"send_after": datetime(2026, 2, 12, 11, 21, 9)}
+        serialized = Arguments.serialize_args_and_kwargs(args, kwargs)
+        deserialized_args, deserialized_kwargs = Arguments.deserialize_args_and_kwargs(
+            serialized
+        )
+        self.assertEqual(list(args), deserialized_args)
+        self.assertEqual(kwargs, deserialized_kwargs)
+
+    def test_datetime_in_list(self):
+        subject = [datetime(2026, 1, 1), datetime(2026, 6, 15)]
+        self.assertEqual(
+            [subject], Arguments.deserialize(Arguments.serialize([subject]))
+        )
+
+    def test_datetime_in_dict(self):
+        subject = {"start": datetime(2026, 1, 1), "end": datetime(2026, 12, 31)}
+        self.assertEqual(
+            [subject], Arguments.deserialize(Arguments.serialize([subject]))
+        )
+
+    def test_timezone_aware_datetime_serialization(self):
+        subjects = [
+            dj_tz.now(),
+            datetime(2026, 2, 12, 11, 21, 9, tzinfo=timezone.utc),
+            datetime(2026, 6, 15, 8, 0, 0, tzinfo=timezone(timedelta(hours=2))),
+        ]
+        for subject in subjects:
+            self.assertEqual(
+                [subject], Arguments.deserialize(Arguments.serialize([subject]))
+            )
+
+    def test_timedelta_serialization(self):
+        subjects = [
+            timedelta(days=1),
+            timedelta(hours=2, minutes=30),
+            timedelta(seconds=0),
+            timedelta(days=7, hours=3, minutes=15, seconds=30, microseconds=500000),
+            timedelta(days=-1, seconds=3600),
+        ]
+        for subject in subjects:
+            self.assertEqual(
+                [subject], Arguments.deserialize(Arguments.serialize([subject]))
+            )
+
+    def test_timedelta_as_kwarg(self):
+        args = ()
+        kwargs = {"delay": timedelta(minutes=5)}
+        serialized = Arguments.serialize_args_and_kwargs(args, kwargs)
+        _, deserialized_kwargs = Arguments.deserialize_args_and_kwargs(serialized)
+        self.assertEqual(kwargs, deserialized_kwargs)
 
 
 class TestModelSerialization(TestCase):


### PR DESCRIPTION
## Summary

- Adds serialization/deserialization support for `datetime`, `date`, `time`, and `timedelta` objects in task arguments, using ISO format strings and sentinel keys (`__sq_datetime__`, `__sq_date__`, `__sq_time__`, `__sq_timedelta__`).
- Includes 7 new regression tests covering plain and timezone-aware datetimes, timedeltas, nesting in lists/dicts, and kwargs.
- Adds a changelog entry under v0.1.5.

Fixes #30

## Test plan

- [x] `test_datetime_serialization` — round-trips `datetime`, `date`, and `time`
- [x] `test_datetime_as_kwarg` — datetime passed as a keyword argument (exact scenario from the issue)
- [x] `test_datetime_in_list` — datetimes nested in a list
- [x] `test_datetime_in_dict` — datetimes nested in a dict
- [x] `test_timezone_aware_datetime_serialization` — `django.utils.timezone.now()` and explicit timezone offsets
- [x] `test_timedelta_serialization` — various timedeltas including negative and microsecond precision
- [x] `test_timedelta_as_kwarg` — timedelta passed as a keyword argument
- [x] Full test suite passes (154 tests)


Made with [Cursor](https://cursor.com)