### PR TITLE
Use GitHub Actions services for PostgreSQL in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,21 @@ jobs:
       matrix:
         python-version: ["3.13", "3.14"]
 
+    services:
+      postgres:
+        image: postgres:17.4-alpine
+        env:
+          POSTGRES_DB: app
+          POSTGRES_USER: steady_queue
+          POSTGRES_PASSWORD: steady_queue
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U steady_queue -d postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
 
@@ -28,9 +43,12 @@ jobs:
         run: |
           uv sync
 
+      - name: Create queue database
+        run: |
+          PGPASSWORD=steady_queue psql -h localhost -U steady_queue -d postgres -c "CREATE DATABASE queue OWNER steady_queue"
+
       - name: Run tests
         run: |
-          tests/bin/run-docker-postgres
           uv run coverage run runtests.py
 
       - name: Report coverage


### PR DESCRIPTION
## Summary

- Replace manual `docker run` + `pg_isready` retry loop with a native GitHub Actions `services` block for PostgreSQL, which has built-in health checks that guarantee the database is fully ready before any steps run.
- Add a dedicated step to create the `queue` database (the `app` database is created automatically via `POSTGRES_DB`).
- Fixes flaky CI failures like https://github.com/knifecake/steady-queue/actions/runs/22073789145/job/63784358102 where tests started before PostgreSQL was accepting connections.

## Test plan

- [x] Verify CI passes on this PR's own test run
- [x] Confirm both `app` and `queue` databases are created (test suite exercises both)

Made with [Cursor](https://cursor.com)