### PR TITLE
Fix CI not running on slash-named branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: ["*"]
+    branches: ["**"]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- The `branches: ["*"]` glob in `test.yml` does not match branch names containing `/` (e.g. `fix/foo`, `feature/bar`)
- This caused the test workflow to never trigger for those PRs, leaving them perpetually waiting for status checks
- Switch to `branches: ["**"]` which matches all branch names including those with slashes

## Test plan

- [ ] Push to a branch named `fix/something` and verify the Test workflow triggers
- [ ] Confirm PRs on slash-named branches no longer hang waiting for status

🤖 Generated with [Claude Code](https://claude.com/claude-code)