### PR TITLE
Add Sphinx documentation site with ReadTheDocs setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ wheels/
 # temporary files
 tmp/
 .mypy_cache/
+
+# Sphinx docs build output
+docs/_build/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.13"
+  commands:
+    - asdf plugin add uv
+    - asdf install uv 0.10.2
+    - asdf global uv 0.10.2
+    - uv sync --group docs --frozen
+    - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**Added:**
+
+- Sphinx documentation site covering installation, getting started,
+  configuration, API reference, internals and alternatives (#13). Published
+  to Read The Docs.
+
 **Fixed:**
 
 - Fixed a bug where the process would hang on shutdown and require `kill -9`.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ lint:
 	uv run ruff check --fix
 	uv run ruff format
 
+.PHONY: docs
+docs:
+	uv run --group docs -m sphinx -b html docs docs/_build/html
+
 .PHONY: force-kill
 force-kill:
 	ps | grep steady_queue | cut -f 1  -d ' '  | xargs kill -9

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,14 @@
+# Minimal makefile for Sphinx documentation
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= uv run sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -1,0 +1,88 @@
+============
+Alternatives
+============
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+vs django-tasks
+---------------
+
+`django-tasks <https://github.com/RealOrangeOne/django-tasks>`_ is the
+third-party package that defined the ``django.tasks`` interface (DEP 0014) and
+served as its reference implementation. It ships a ``DatabaseBackend`` that
+stores and executes tasks using your application's database.
+
+The ``django-tasks`` ``DatabaseBackend`` is intentionally minimal. Steady
+Queue is also a database-backed implementation of the same interface, but adds:
+
+- **Cron-style recurring tasks** via the ``@recurring`` decorator.
+- **Concurrency controls** via ``@limits_concurrency``.
+- **Operational visibility**: inspect, retry and discard failed tasks from the
+  Django admin.
+- **Queue pausing**: pause and resume individual queues from the admin.
+- **Horizontal scaling**: run multiple worker or dispatcher processes across
+  machines.
+- **Configurable process topology**: control the number of workers, threads per
+  worker, polling intervals and which queues each worker handles.
+- **Heartbeat-based liveness checks** with automatic task recovery when a
+  worker process dies.
+
+If you just need simple background task execution and none of the above
+features matter to you, ``django-tasks`` is a fine choice. Steady Queue is
+the better fit when you need more operational control or advanced features.
+
+Because both implement the same ``django.tasks`` interface, you can switch
+between them by changing a single line in ``settings.py``.
+
+vs Celery
+---------
+
+Celery is the most widely used task queue library in the Python ecosystem. It
+is mature, has a huge community and supports a wide range of brokers (Redis,
+RabbitMQ, Amazon SQS, etc.).
+
+The main trade-off is operational complexity: Celery requires a separate broker
+process (typically Redis or RabbitMQ) that must be deployed, monitored and
+maintained. Steady Queue uses your existing database, so there's nothing new to
+operate.
+
+Celery also has its own task definition interface (``@app.task`` / ``@shared_task``),
+whereas Steady Queue follows the standard ``django.tasks`` interface (DEP 0014),
+which keeps your task code portable across compliant backends.
+
+Consider Celery if you need features like task routing to heterogeneous worker
+pools, support for non-relational brokers, or the rich ecosystem of
+third-party Celery extensions. Consider Steady Queue if you'd rather not
+introduce a broker dependency and your workloads fit comfortably within a
+relational database.
+
+vs django-rq
+------------
+
+`django-rq <https://github.com/rq/django-rq>`_ integrates the `RQ
+<https://python-rq.org/>`_ task queue (which uses Redis as a broker) with
+Django. Like Celery, it requires Redis to be running. It is simpler than
+Celery and easier to set up, but still adds operational overhead compared to a
+pure database solution.
+
+vs Solid Queue
+--------------
+
+`Solid Queue <https://github.com/rails/solid_queue>`_ is the Ruby on Rails
+library that Steady Queue is ported from. If you're coming from a Rails
+background, the concepts and configuration will look familiar. The main
+differences in the external interface are:
+
+- **Task definition.** Solid Queue works with Active Job classes; Steady Queue
+  uses the ``@task`` decorator from DEP 0014.
+- **Priority ordering.** Steady Queue follows Django's convention where *larger*
+  numbers mean *higher* priority (e.g. priority 10 runs before priority 0).
+  Solid Queue uses the inverse.
+- **Recurring tasks.** Solid Queue supports command-based recurring tasks
+  (arbitrary shell commands on a schedule). Steady Queue only supports
+  recurring Python task functions.
+- **Instrumentation.** Solid Queue emits rich ``ActiveSupport::Notifications``
+  events. Steady Queue uses standard Python logging and the ``django.tasks``
+  signals instead.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,153 @@
+=============
+API Reference
+=============
+
+Steady Queue's public API is intentionally small. Most of the interface comes
+from Django's ``django.tasks`` module (see the `Django tasks documentation
+<https://docs.djangoproject.com/en/stable/ref/tasks/>`_). Steady Queue adds
+two decorators and a handful of module-level settings.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+
+.. _api-recurring:
+
+@recurring
+----------
+
+.. autofunction:: steady_queue.recurring_task.recurring
+
+The ``@recurring`` decorator registers a task to be enqueued automatically on
+a cron schedule. It must be applied *outside* the ``@task()`` decorator:
+
+.. code-block:: python
+
+    from django.tasks import task
+    from steady_queue.recurring_task import recurring
+
+    @recurring(schedule="0 9 * * 1-5", key="weekly_report")
+    @task()
+    def weekly_report():
+        ...
+
+The same task can have multiple recurring schedules:
+
+.. code-block:: python
+
+    @recurring(schedule="0 9 * * *", args=("Alice",), key="greet_alice")
+    @recurring(schedule="0 12 * * *", args=("Bob",), key="greet_bob")
+    @task()
+    def greet(name: str):
+        print(f"Hello, {name}!")
+
+Parameters:
+
+``schedule``
+    A crontab expression (anything understood by the `crontab
+    <https://pypi.org/project/crontab/>`_ library). For example:
+
+    - ``"* * * * *"`` — every minute
+    - ``"0 9 * * 1-5"`` — 9am on weekdays
+    - ``"@daily"`` — once a day at midnight
+
+``key``
+    A unique string identifier for this recurring configuration. Must be
+    unique across all ``@recurring`` decorators in your codebase. Used to
+    prevent duplicate runs when multiple schedulers are active.
+
+``args``
+    Positional arguments to pass to the task when it is enqueued. Defaults to
+    no arguments.
+
+``kwargs``
+    Keyword arguments to pass to the task when it is enqueued.
+
+``queue_name``
+    The queue to enqueue the task on. If omitted, uses the queue from the
+    ``@task()`` decorator or the default queue.
+
+``priority``
+    Numeric priority for the enqueued task. If omitted, uses the priority from
+    the ``@task()`` decorator or ``0``.
+
+``description``
+    Optional human-readable description. Currently unused but stored for
+    future tooling.
+
+
+.. _api-limits-concurrency:
+
+@limits_concurrency
+-------------------
+
+.. autofunction:: steady_queue.concurrency.limits_concurrency
+
+The ``@limits_concurrency`` decorator restricts how many instances of a task
+can run at the same time. It must be applied *outside* the ``@task()``
+decorator:
+
+.. code-block:: python
+
+    from django.tasks import task
+    from steady_queue.concurrency import limits_concurrency
+
+    @limits_concurrency(key=lambda user_id: str(user_id), to=1)
+    @task()
+    def generate_report(user_id: int):
+        ...
+
+Parameters:
+
+``key``
+    **Required.** A string or a callable that accepts the same arguments as
+    the task and returns a string. Tasks with the same key value are counted
+    together for the concurrency limit.
+
+``to``
+    Maximum number of tasks with the same key that may run simultaneously.
+    Defaults to ``1``.
+
+``duration``
+    How long the concurrency guarantee is held. If a task holds a concurrency
+    slot for longer than this, the slot may be released by the dispatcher's
+    maintenance pass. Defaults to
+    ``steady_queue.default_concurrency_control_period`` (3 minutes).
+
+``group``
+    A string used to apply a shared concurrency limit across different task
+    types. Tasks from different functions that share the same ``group`` and
+    ``key`` value count against the same limit. Defaults to the task's module
+    path.
+
+
+Argument serialization
+----------------------
+
+Task functions accept almost any argument type as positional or keyword
+arguments. Beyond the standard DEP 0014 serializable types, Steady Queue adds
+support for:
+
+- ``datetime`` and ``date`` objects
+- ``timedelta`` objects
+- Django model instances (serialized as content type + primary key)
+
+If a model instance cannot be found in the database when the task is executed,
+a ``steady_queue.arguments.DeserializationError`` is raised.
+
+
+Backend limitations
+-------------------
+
+The ``SteadyQueueBackend`` does not support the following features defined by
+the Django task backend interface:
+
+- **Async enqueueing** — tasks cannot be enqueued from async code.
+- **Result fetching** — ``task_result.return_value`` is not supported. Store
+  results directly in your database or file storage if they need to be
+  persisted.
+
+These limitations are advertised via the
+`Django task feature flags
+<https://docs.djangoproject.com/en/stable/ref/tasks/#feature-flags>`_.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+import django
+
+project = "Steady Queue"
+copyright = "2025, Elias Hernandis"
+author = "Elias Hernandis"
+
+# Make source available for autodoc
+os.environ["DJANGO_SETTINGS_MODULE"] = "tests.settings"
+sys.path.insert(0, os.path.abspath(".."))
+django.setup()
+
+import steady_queue  # noqa: E402
+
+release = steady_queue.__version__
+
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+]
+
+templates_path = ["_templates"]
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "alabaster"
+html_static_path = ["_static"]
+
+html_theme_options = {
+    "description": "A database-backed task backend for Django",
+    "github_user": "knifecake",
+    "github_repo": "steady-queue",
+    "github_button": True,
+    "github_type": "star",
+}
+
+# -- Napoleon extension configuration ----------------------------------------
+
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,242 @@
+==============
+Configuration
+==============
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+TASKS setting
+-------------
+
+Steady Queue is configured as a Django task backend under the ``TASKS``
+setting:
+
+.. code-block:: python
+
+    # settings.py
+    TASKS = {
+        "default": {
+            "BACKEND": "steady_queue.backend.SteadyQueueBackend",
+            "QUEUES": ["default"],
+            "OPTIONS": {},
+        }
+    }
+
+You can add multiple backends (e.g. for incremental adoption):
+
+.. code-block:: python
+
+    TASKS = {
+        "default": {
+            "BACKEND": "steady_queue.backend.SteadyQueueBackend",
+            "QUEUES": ["default"],
+        },
+        "legacy": {
+            "BACKEND": "...",
+        },
+    }
+
+
+STEADY_QUEUE setting
+--------------------
+
+The ``STEADY_QUEUE`` setting configures the workers, dispatchers and scheduler
+that run when you execute ``python manage.py steady_queue``. All options are
+optional and will fall back to sensible defaults.
+
+.. code-block:: python
+
+    # settings.py
+    from steady_queue.configuration import Configuration
+    from datetime import timedelta
+
+    STEADY_QUEUE = Configuration.Options(
+        dispatchers=[
+            Configuration.Dispatcher(
+                polling_interval=timedelta(seconds=1),
+                batch_size=500,
+            )
+        ],
+        workers=[
+            Configuration.Worker(
+                queues=["default"],
+                threads=3,
+                polling_interval=timedelta(seconds=0.1),
+            )
+        ],
+    )
+
+Workers
+~~~~~~~
+
+Each ``Configuration.Worker`` entry spawns one or more processes that poll
+queues and execute tasks.
+
+- ``queues`` — list of queue names to process. Use ``"*"`` (or omit) to
+  process all queues. Prefix wildcards are supported (e.g. ``"staging*"``).
+  Queue names are checked in order: tasks in the first queue are processed
+  before tasks in the second queue, regardless of priority.
+- ``threads`` — size of the thread pool used to run tasks concurrently within
+  a single worker process. Defaults to ``3``. Recommended to be ≤ the
+  database connection pool size minus 2.
+- ``processes`` — number of worker processes to fork with this configuration.
+  Defaults to ``1``.
+- ``polling_interval`` — time between polls when there are no tasks waiting.
+  Defaults to ``0.1`` seconds.
+
+Dispatchers
+~~~~~~~~~~~
+
+Each ``Configuration.Dispatcher`` entry spawns a process that moves scheduled
+tasks to the ready queue and performs concurrency-control maintenance.
+
+- ``polling_interval`` — time between dispatcher polls. Defaults to ``1``
+  second.
+- ``batch_size`` — number of scheduled tasks dispatched per cycle. Defaults
+  to ``500``.
+- ``concurrency_maintenance_interval`` — time between concurrency control
+  maintenance runs. Defaults to ``600`` seconds.
+- ``concurrency_maintenance`` — whether this dispatcher performs concurrency
+  maintenance at all. Defaults to ``True``. Set to ``False`` if you run
+  multiple dispatchers and want some dedicated to dispatching only.
+
+Queue order and priorities
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Within a single queue, tasks are ordered by numeric priority (higher numbers
+run first; default ``0``). Across multiple queues specified for a worker, the
+order of the list takes precedence: a task in the first queue will always be
+picked before a task in the second queue, even if the second has a higher
+priority.
+
+Avoid mixing queue order with task priorities — choose one or the other to
+keep execution order predictable.
+
+.. _database-configuration:
+
+Database configuration
+----------------------
+
+By default, Steady Queue stores its tables in the ``default`` database. For
+production we recommend using a dedicated database to avoid accidentally
+relying on transactional integrity between your application data and your job
+queue.
+
+1. Add a ``queue`` entry to ``DATABASES``:
+
+   .. code-block:: python
+
+       DATABASES = {
+           "default": {...},
+           "queue": {
+               "ENGINE": "django.db.backends.postgresql",
+               "NAME": "queue",
+               "USER": "queue",
+               "PASSWORD": "queue",
+               "HOST": "localhost",
+               "PORT": 5432,
+               "TEST": {"NAME": "test_queue"},
+           },
+       }
+
+2. Point Steady Queue at that alias and register the database router:
+
+   .. code-block:: python
+
+       import steady_queue
+
+       steady_queue.database = "queue"
+       DATABASE_ROUTERS = ["steady_queue.db_router.SteadyQueueRouter"]
+
+3. Run migrations against the dedicated database:
+
+   .. code-block:: bash
+
+       python manage.py migrate --database queue steady_queue
+
+Module-level settings
+---------------------
+
+These settings are set directly on the ``steady_queue`` module, typically in
+``settings.py``:
+
+.. code-block:: python
+
+    import steady_queue
+    from datetime import timedelta
+
+    steady_queue.database = "queue"
+    steady_queue.process_heartbeat_interval = timedelta(minutes=2)
+
+Available settings:
+
+``steady_queue.database``
+    The database alias used for all Steady Queue tables. Defaults to
+    ``"default"``. See :ref:`database-configuration`.
+
+``steady_queue.process_heartbeat_interval``
+    How often supervised processes send a heartbeat. Defaults to 1 minute.
+
+``steady_queue.process_alive_threshold``
+    How long after the last heartbeat a process is considered dead. Defaults
+    to 5 minutes.
+
+``steady_queue.shutdown_timeout``
+    How long the supervisor waits after sending ``TERM`` before sending
+    ``QUIT`` to force-stop supervised processes. Defaults to 5 seconds.
+
+``steady_queue.supervisor_pidfile``
+    Path to a PID file created by the supervisor. Used to prevent multiple
+    supervisors on the same host and as a health check target. Defaults to
+    ``tmp/pids/steady_queue_supervisor.pid``.
+
+``steady_queue.preserve_finished_jobs``
+    Whether to keep finished jobs in the ``steady_queue_jobs`` table. Defaults
+    to ``True``. When ``False``, completed jobs are deleted immediately.
+
+``steady_queue.clear_finished_jobs_after``
+    How long to retain finished jobs when ``preserve_finished_jobs`` is
+    ``True``. Defaults to 1 day. Note: there is no automatic cleanup — call
+    ``Job.objects.clear_finished_in_batches()`` periodically (e.g. as a
+    recurring task).
+
+``steady_queue.default_concurrency_control_period``
+    Default value for the ``duration`` parameter in
+    :ref:`concurrency controls <api-limits-concurrency>`. Defaults to 3
+    minutes.
+
+Signals
+-------
+
+Steady Queue emits the standard `django.tasks signals
+<https://docs.djangoproject.com/en/stable/ref/tasks/#signals>`_:
+
+- ``django.tasks.signals.task_enqueued`` — fired when a task is inserted into
+  the database.
+- ``django.tasks.signals.task_started`` — fired when a worker begins executing
+  a task.
+- ``django.tasks.signals.task_finished`` — fired when a task finishes
+  (successfully or with an error).
+
+All signals include ``sender`` (the ``SteadyQueueBackend`` instance) and
+``task_result`` (a ``django.tasks.TaskResult``).
+
+Logging
+-------
+
+Steady Queue logs to the ``steady_queue`` logger using the standard Python
+``logging`` module. Add it to ``LOGGING`` in ``settings.py`` to control
+verbosity:
+
+.. code-block:: python
+
+    LOGGING = {
+        "loggers": {
+            "steady_queue": {
+                "handlers": ["console"],
+                "level": "INFO",
+            },
+        },
+        # ...
+    }

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,0 +1,131 @@
+===============
+Getting Started
+===============
+
+Steady Queue implements the `django.tasks
+<https://docs.djangoproject.com/en/stable/ref/tasks/>`_ interface (DEP 0014),
+so most of what you need to know is already covered in the Django documentation.
+This guide focuses on what's specific to Steady Queue and how to get up and
+running quickly.
+
+Defining tasks
+--------------
+
+Tasks are plain Python functions decorated with ``@task`` from ``django.tasks``:
+
+.. code-block:: python
+
+    from django.tasks import task
+
+    @task()
+    def send_welcome_email(user_id: int):
+        user = User.objects.get(pk=user_id)
+        # ... send the email
+
+Enqueueing tasks
+----------------
+
+Call ``.enqueue()`` on the decorated function to run it in the background:
+
+.. code-block:: python
+
+    send_welcome_email.enqueue(user.pk)
+
+You can customise how a task is enqueued using ``.using()``:
+
+.. code-block:: python
+
+    # Run with a higher priority
+    send_welcome_email.using(priority=10).enqueue(user.pk)
+
+    # Run on a specific queue
+    send_welcome_email.using(queue_name="email").enqueue(user.pk)
+
+    # Run after a delay
+    from django.utils import timezone
+    from datetime import timedelta
+
+    send_welcome_email.using(run_after=timedelta(minutes=5)).enqueue(user.pk)
+
+Task decorator options
+----------------------
+
+These options can be set on the ``@task`` decorator as defaults:
+
+.. code-block:: python
+
+    @task(priority=10, queue_name="email", backend="default")
+    def send_welcome_email(user_id: int):
+        ...
+
+- ``priority`` — integer between -100 and 100; higher numbers run first.
+  Defaults to ``0``.
+- ``queue_name`` — the queue where this task will be enqueued. Defaults to
+  ``"default"``.
+- ``backend`` — the key in ``TASKS`` settings to use. Defaults to
+  ``"default"``.
+
+Enqueueing after a transaction commits
+---------------------------------------
+
+When you enqueue a task inside a database transaction, it's possible that the
+task is picked up by a worker before the transaction commits, or that the
+transaction rolls back after the task has been enqueued. To avoid this, use
+Django's ``transaction.on_commit``:
+
+.. code-block:: python
+
+    from django.db import transaction
+    from functools import partial
+
+    def sign_up(request):
+        user = User.objects.create(...)
+        transaction.on_commit(partial(send_welcome_email.enqueue, user.pk))
+
+Running the worker
+------------------
+
+Start Steady Queue with Django's management command:
+
+.. code-block:: bash
+
+    python manage.py steady_queue
+
+This will start one dispatcher and one worker with the default configuration.
+See :doc:`configuration` for how to customise the number of workers, queues,
+and polling intervals.
+
+Recurring tasks
+---------------
+
+Steady Queue can enqueue tasks on a schedule, like a cron job:
+
+.. code-block:: python
+
+    from django.tasks import task
+    from steady_queue.recurring_task import recurring
+
+    @recurring(schedule="0 9 * * *", key="daily_digest")
+    @task()
+    def send_daily_digest():
+        # runs every day at 9am
+        ...
+
+See :ref:`api-recurring` for the full ``@recurring`` API.
+
+Concurrency controls
+--------------------
+
+Prevent too many instances of a task from running at the same time:
+
+.. code-block:: python
+
+    from django.tasks import task
+    from steady_queue.concurrency import limits_concurrency
+
+    @limits_concurrency(key=lambda user_id: str(user_id), to=1)
+    @task()
+    def process_user_export(user_id: int):
+        ...
+
+See :ref:`api-limits-concurrency` for the full ``@limits_concurrency`` API.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,36 @@
+============
+Steady Queue
+============
+
+Steady Queue is a database-backed task backend for Django 6.0+. It is a port
+to Python of the excellent `Solid Queue <https://github.com/rails/solid_queue>`_
+backend for Ruby on Rails, and it is compatible with the
+`django.tasks <https://docs.djangoproject.com/en/stable/ref/tasks/>`_ interface.
+
+It lets you run background jobs using only your existing relational database.
+By leveraging ``SELECT FOR UPDATE SKIP LOCKED``, Steady Queue provides a
+high-performance, concurrency-safe queuing system without the operational
+overhead of Redis or RabbitMQ.
+
+Features
+--------
+
+- **Task enqueueing and processing.** Using the standard ``@task`` decorator
+  introduced in `DEP 0014 <https://github.com/django/deps/blob/main/accepted/0014-background-workers.rst>`_,
+  with support for queue selection, delayed tasks and numeric priorities.
+- **No extra infrastructure.** Works with MySQL, PostgreSQL or SQLite.
+- **Cron-style recurring tasks.** Define schedules directly in your code.
+- **Concurrency controls.** Limit how many instances of a task run simultaneously.
+- **Operational control.** Pause and resume queues, inspect and retry failed
+  tasks via the Django admin.
+
+
+.. toctree::
+   :maxdepth: 2
+
+   installation
+   getting_started
+   configuration
+   api
+   internals
+   alternatives

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,59 @@
+============
+Installation
+============
+
+Requirements
+------------
+
+- Python 3.12+
+- Django 6.0+
+- A supported SQL database: MySQL 8+, PostgreSQL 9.5+, or SQLite
+
+Steps
+-----
+
+1. **Install the package:**
+
+   .. code-block:: bash
+
+       pip install steady-queue
+
+2. **Add the app** to ``INSTALLED_APPS`` in ``settings.py``:
+
+   .. code-block:: python
+
+       INSTALLED_APPS = [
+           # ...
+           "steady_queue",
+       ]
+
+3. **Configure a task backend** in ``settings.py``:
+
+   .. code-block:: python
+
+       TASKS = {
+           "default": {
+               "BACKEND": "steady_queue.backend.SteadyQueueBackend",
+               "QUEUES": ["default"],
+               "OPTIONS": {},
+           }
+       }
+
+4. **Run migrations:**
+
+   .. code-block:: bash
+
+       python manage.py migrate
+
+5. **Start the worker** on your server:
+
+   .. code-block:: bash
+
+       python manage.py steady_queue
+
+
+That's it! Tasks decorated with ``@task()`` will now be processed by Steady
+Queue.
+
+For larger projects you may want to configure a dedicated database for Steady
+Queue. See :ref:`database-configuration` in the configuration guide.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1,0 +1,200 @@
+==================
+Design & Internals
+==================
+
+This page describes how Steady Queue works internally. You don't need to
+understand any of this to use it, but it may help when tuning performance,
+debugging issues or contributing to the project.
+
+Steady Queue is a port of `Solid Queue <https://github.com/rails/solid_queue>`_
+from Ruby on Rails. The architecture maps closely to the original; the main
+differences are in the external interface (Django's ``@task`` decorator instead
+of ActiveJob classes) and the ORM (Django ORM instead of Active Record).
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+Actors
+------
+
+When you run ``python manage.py steady_queue``, a **supervisor** process is
+started. The supervisor forks and monitors the following types of child
+processes:
+
+**Workers**
+    Workers poll the ``steady_queue_ready_executions`` table for tasks ready
+    to run. Each worker maintains a thread pool (configurable via ``threads``)
+    and fetches that many tasks at a time, posting them to threads for
+    execution.
+
+**Dispatchers**
+    Dispatchers poll the ``steady_queue_scheduled_executions`` table for tasks
+    whose scheduled run time has passed and moves them to
+    ``steady_queue_ready_executions`` so workers can pick them up. Dispatchers
+    also perform concurrency-control maintenance (releasing expired semaphores
+    and unblocking waiting tasks).
+
+**Scheduler**
+    A single scheduler process manages recurring tasks. It reads the list of
+    ``@recurring`` configurations registered in the codebase and enqueues them
+    when their schedule is due.
+
+The supervisor monitors child processes via heartbeats, restarts them if they
+die unexpectedly, and coordinates graceful shutdown.
+
+Database tables
+---------------
+
+``steady_queue_jobs``
+    The primary record for each task invocation. Holds the task module path,
+    serialized arguments, queue name, priority and status. Rows are kept after
+    completion if ``preserve_finished_jobs`` is ``True``.
+
+``steady_queue_ready_executions``
+    Pointers to jobs that are ready to be picked up by a worker. Workers poll
+    this table with ``SELECT FOR UPDATE SKIP LOCKED``.
+
+``steady_queue_scheduled_executions``
+    Pointers to jobs that should run in the future. Dispatchers move rows from
+    here to ``steady_queue_ready_executions`` when the ``scheduled_at`` time
+    is reached.
+
+``steady_queue_blocked_executions``
+    Jobs that are waiting for a concurrency semaphore. Dispatchers unblock them
+    during maintenance runs.
+
+``steady_queue_semaphores``
+    Tracks active concurrency limits. Each row corresponds to one open
+    concurrency slot.
+
+``steady_queue_recurringexecution``
+    Records of scheduled recurring task runs. A unique index on
+    ``(task_key, run_at)`` prevents duplicate enqueues when multiple
+    schedulers run concurrently.
+
+``steady_queue_processes``
+    Heartbeat records for all supervised processes. The supervisor prunes
+    processes with expired heartbeats and marks their in-flight tasks as
+    failed.
+
+``steady_queue_pauses``
+    Records of paused queues. Workers check this table to skip paused queues.
+
+Polling strategy
+----------------
+
+To keep polling efficient, Steady Queue issues only two forms of polling
+query:
+
+.. code-block:: sql
+
+    -- All queues (used when queues=['*'] and nothing is paused)
+    SELECT job_id
+    FROM steady_queue_ready_executions
+    ORDER BY priority DESC, job_id ASC
+    LIMIT ?
+    FOR UPDATE SKIP LOCKED;
+
+    -- Single queue (used for exact queue names)
+    SELECT job_id
+    FROM steady_queue_ready_executions
+    WHERE queue_name = ?
+    ORDER BY priority DESC, job_id ASC
+    LIMIT ?
+    FOR UPDATE SKIP LOCKED;
+
+Both queries use a covering index on ``(queue_name, priority, job_id)`` and
+avoid full table scans. When wildcards or paused queues are involved, an
+additional ``DISTINCT`` query is required to enumerate matching queue names —
+this is fast on MySQL (Loose Index Scan) but may be slower on PostgreSQL or
+SQLite with large tables.
+
+For optimal polling performance, specify exact queue names and avoid pausing
+queues.
+
+``FOR UPDATE SKIP LOCKED``
+--------------------------
+
+The key to Steady Queue's concurrency safety is the ``FOR UPDATE SKIP LOCKED``
+SQL clause, available in MySQL 8+, PostgreSQL 9.5+ and SQLite 3.25+. This
+allows multiple worker threads or processes to poll the same table
+simultaneously without blocking each other: each worker locks the rows it is
+about to process, and other workers transparently skip those rows.
+
+On databases that don't support ``SKIP LOCKED``, workers may block waiting for
+row locks from other workers. The system remains correct but throughput will be
+lower.
+
+Concurrency controls
+--------------------
+
+The ``@limits_concurrency`` decorator uses a semaphore table to enforce
+concurrency limits. The flow is:
+
+1. **Enqueue time:** Steady Queue computes the concurrency key and checks the
+   semaphore table. If the semaphore count is below the limit, the count is
+   incremented and the task is inserted as ``ready``. If the limit is reached,
+   the task is inserted as ``blocked``.
+
+2. **After task completion:** the semaphore count is decremented and the next
+   blocked task with the same key (highest priority first) is moved to
+   ``ready``.
+
+3. **Dispatcher maintenance:** If a semaphore is held for longer than
+   ``duration`` (e.g. the worker holding it was killed), the dispatcher's
+   maintenance pass releases it and unblocks the next waiting task. The
+   ``concurrency_maintenance_interval`` on the dispatcher controls how often
+   this check runs.
+
+Process lifecycle and signals
+-----------------------------
+
+The supervisor handles the following signals:
+
+``TERM``, ``INT``
+    Graceful shutdown. The supervisor forwards ``TERM`` to all child processes
+    and waits up to ``shutdown_timeout`` for them to finish. Any processes
+    still running after the timeout receive ``QUIT``.
+
+``QUIT``
+    Immediate shutdown. Child processes exit immediately. In-flight tasks are
+    returned to the queue when processes deregister.
+
+If a process exits unexpectedly (e.g. via ``SIGKILL``) its in-flight tasks
+are marked as failed with a ``ProcessExitError`` exception. If the supervisor
+detects a process with an expired heartbeat, it prunes the process record and
+marks those tasks as failed with a ``ProcessPrunedError``.
+
+Argument serialization
+----------------------
+
+Steady Queue extends the serialization format defined by DEP 0014 to support
+additional Python types:
+
+- ``datetime`` / ``date`` — serialized as ISO 8601 strings.
+- ``timedelta`` — serialized as total seconds.
+- Django model instances — serialized as ``{"content_type": ..., "pk": ...}``.
+  At execution time, the model is re-fetched from the database. If the row no
+  longer exists, ``DeserializationError`` is raised.
+
+Transactional integrity
+-----------------------
+
+When Steady Queue shares a database with your application, enqueueing a task
+inside a transaction makes the task visible to workers only after the
+transaction commits. This can be useful (the task is guaranteed to see
+consistent data) but also surprising if you're not aware of it.
+
+When Steady Queue uses a separate database, this transactional coupling is
+absent. To safely enqueue tasks after a transaction commits regardless of
+database configuration, use Django's ``transaction.on_commit``:
+
+.. code-block:: python
+
+    from django.db import transaction
+    from functools import partial
+
+    def create_user(data):
+        user = User.objects.create(**data)
+        transaction.on_commit(partial(send_welcome_email.enqueue, user.pk))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ ignore_missing_imports = true
 django_settings_module = "tests.settings"
 
 [dependency-groups]
+docs = [
+    "sphinx>=8.0",
+]
 dev = [
     "coverage>=7.13.4",
     "django-environ>=0.12.0",

--- a/steady_queue/recurring_task.py
+++ b/steady_queue/recurring_task.py
@@ -20,7 +20,7 @@ def recurring(
     """
     Decorator for registering a task to run on a recurring schedule.
 
-    Usage:
+    Example::
 
         @recurring(schedule="*/1 * * * *", key="unique_task_key")
         @task()

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "alabaster"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -21,12 +30,87 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
+    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
+    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
 ]
 
 [[package]]
@@ -203,6 +287,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -227,6 +320,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/8d/e8b97e6bd3fb6fb271346f7981362f1e04d6a7463abd0de79e1fda17c067/identify-2.6.16.tar.gz", hash = "sha256:846857203b5511bbe94d5a352a48ef2359532bc8f6727b5544077a0dcfb24980", size = 99360, upload-time = "2026-01-12T18:58:58.201Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/58/40fbbcefeda82364720eba5cf2270f98496bdfa19ea75b4cccae79c698e6/identify-2.6.16-py2.py3-none-any.whl", hash = "sha256:391ee4d77741d994189522896270b787aed8670389bfd60f326d677d64a6dfb0", size = 99202, upload-time = "2026-01-12T18:58:56.627Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "imagesize"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a", size = 1280026, upload-time = "2022-07-01T12:21:05.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b", size = 8769, upload-time = "2022-07-01T12:21:02.467Z" },
 ]
 
 [[package]]
@@ -272,6 +383,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -335,6 +458,69 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "matplotlib-inline"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -395,6 +581,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
 ]
 
 [[package]]
@@ -611,6 +806,30 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "roman-numerals"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.2"
 source = { registry = "https://pypi.org/simple" }
@@ -633,6 +852,97 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
     { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
     { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+]
+
+[[package]]
+name = "snowballstemmer"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]
@@ -680,6 +990,9 @@ dev = [
     { name = "ty" },
     { name = "types-python-crontab" },
 ]
+docs = [
+    { name = "sphinx" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -701,6 +1014,7 @@ dev = [
     { name = "ty", specifier = ">=0.0.1a17" },
     { name = "types-python-crontab", specifier = ">=3.3.0.20250715" },
 ]
+docs = [{ name = "sphinx", specifier = ">=8.0" }]
 
 [[package]]
 name = "traitlets"
@@ -781,6 +1095,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #13.

## Summary

- Adds a `docs/` directory with Sphinx documentation covering all sections from the issue: installation, getting started, configuration, API reference, design & internals, and alternatives
- Adds `.readthedocs.yaml` for ReadTheDocs build configuration (following the django-anchor pattern, using uv 0.10.2)
- Adds a `docs` dependency group to `pyproject.toml` and a `make docs` target
- Minor fix to the `@recurring` docstring RST formatting

## Test plan

- [x] `make docs` builds cleanly with no warnings
- [x] Import project on readthedocs.org to verify the live build

🤖 Generated with [Claude Code](https://claude.com/claude-code)