### PR TITLE
release v0.1.8

### DIFF
--- a/steady_queue/__init__.py
+++ b/steady_queue/__init__.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Optional
 
-VERSION = (0, 1, 7)
+VERSION = (0, 1, 8)
 
 __version__ = ".".join(map(str, VERSION))
 


### PR DESCRIPTION
Prepare v0.1.8 release by bumping package version in steady_queue/__init__.py to match the changelog entry already merged.